### PR TITLE
Update VSTHost require path to work with npm installed module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install node-vst-host
 ### Usage
 
 ```javascript
-var VSTHost = require("./node-vst-host").host;
+var VSTHost = require("node-vst-host").host;
 
 var host = new VSTHost();
 


### PR DESCRIPTION
Updated the README example to use the path to npm installed module.
